### PR TITLE
add persist credentials to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:


### PR DESCRIPTION
### やったこと
- release.yml からcheckoutオプションの`persist-credentials: false`を削除
  -  akashic-games/action-release が git push時にgithubユーザー情報を必要とするため